### PR TITLE
chore(CVEs): update lib versions for fixing CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <slf4j.version>2.0.4</slf4j.version>
         <logback.version>1.4.11</logback.version>
         <junit.version>4.13.2</junit.version>
-
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,12 @@
     </developers>
 
     <properties>
-        <vertx.version>4.1.5</vertx.version>
-        <hazelcast.version>5.0.3</hazelcast.version>
-        <slf4j.version>1.7.32</slf4j.version>
-        <logback.version>1.2.6</logback.version>
+        <vertx.version>4.4.5</vertx.version>
+        <hazelcast.version>5.3.1</hazelcast.version>
+        <slf4j.version>2.0.4</slf4j.version>
+        <logback.version>1.4.11</logback.version>
         <junit.version>4.13.2</junit.version>
+
     </properties>
 
 


### PR DESCRIPTION
trivy is reporting a bunch of CVEs on the current versions.
So I upgraded them to the more current sain version.
```
trivy fs .
2023-09-07T10:59:41.191+0200    INFO    Vulnerability scanning is enabled
2023-09-07T10:59:41.191+0200    INFO    Secret scanning is enabled
2023-09-07T10:59:41.191+0200    INFO    If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2023-09-07T10:59:41.191+0200    INFO    Please see also https://aquasecurity.github.io/trivy/v0.31.3/docs/secret/scanning/#recommendation for faster secret detection
2023-09-07T10:59:42.255+0200    INFO    Number of language-specific files: 1
2023-09-07T10:59:42.256+0200    INFO    Detecting pom vulnerabilities...

pom.xml (pom)

Total: 7 (UNKNOWN: 0, LOW: 0, MEDIUM: 5, HIGH: 1, CRITICAL: 1)

┌─────────────────────────────┬────────────────┬──────────┬───────────────────┬──────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│           Library           │ Vulnerability  │ Severity │ Installed Version │            Fixed Version             │                            Title                             │
├─────────────────────────────┼────────────────┼──────────┼───────────────────┼──────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ ch.qos.logback:logback-core │ CVE-2021-42550 │ MEDIUM   │ 1.2.6             │ 1.2.8                                │ logback: remote code execution through JNDI call from within │
│                             │                │          │                   │                                      │ its configuration file...                                    │
│                             │                │          │                   │                                      │ https://avd.aquasec.com/nvd/cve-2021-42550                   │
├─────────────────────────────┼────────────────┼──────────┼───────────────────┼──────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.hazelcast:hazelcast     │ CVE-2022-36437 │ CRITICAL │ 5.0.3             │ 3.12.13, 4.1.10, 4.2.6, 5.0.4, 5.1.3 │ Hazelcast connection caching                                 │
│                             │                │          │                   │                                      │ https://avd.aquasec.com/nvd/cve-2022-36437                   │
│                             ├────────────────┼──────────┤                   ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                             │ CVE-2023-33265 │ HIGH     │                   │ 5.0.5, 5.1.7, 5.2.4                  │ Hazelcast Executor Services don't check client permissions   │
│                             │                │          │                   │                                      │ properly                                                     │
│                             │                │          │                   │                                      │ https://avd.aquasec.com/nvd/cve-2023-33265                   │
│                             ├────────────────┼──────────┤                   ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                             │ CVE-2023-33264 │ MEDIUM   │                   │ 5.0.4, 5.1.6, 5.2.3                  │ Improper password mask                                       │
│                             │                │          │                   │                                      │ https://avd.aquasec.com/nvd/cve-2023-33264                   │
├─────────────────────────────┼────────────────┤          ├───────────────────┼──────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ io.netty:netty-codec-http   │ CVE-2021-43797 │          │ 4.1.68.Final      │ 4.1.71                               │ control chars in header names may lead to HTTP request       │
│                             │                │          │                   │                                      │ smuggling                                                    │
│                             │                │          │                   │                                      │ https://avd.aquasec.com/nvd/cve-2021-43797                   │
├─────────────────────────────┼────────────────┤          │                   ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ io.netty:netty-common       │ CVE-2022-24823 │          │                   │ 4.1.77.Final                         │ world readable temporary file containing sensitive data      │
│                             │                │          │                   │                                      │ https://avd.aquasec.com/nvd/cve-2022-24823                   │
├─────────────────────────────┼────────────────┤          │                   ├──────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ io.netty:netty-handler      │ CVE-2023-34462 │          │                   │ 4.1.94.Final                         │ SniHandler 16MB allocation leads to OOM                      │
│                             │                │          │                   │                                      │ https://avd.aquasec.com/nvd/cve-2023-34462                   │
└─────────────────────────────┴────────────────┴──────────┴───────────────────┴──────────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```

The trivy check shows empty CVEs after the update.