### PR TITLE
chore(hazelcast): go back in version to keep it compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <properties>
         <vertx.version>4.4.5</vertx.version>
         <hazelcast.version>5.0.5</hazelcast.version>
+        <slf4j.version>2.0.9</slf4j.version>
         <logback.version>1.4.11</logback.version>
         <junit.version>4.13.2</junit.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -43,10 +43,10 @@
     </developers>
 
     <properties>
-        <vertx.version>4.1.5</vertx.version>
-        <hazelcast.version>5.0.3</hazelcast.version>
-        <slf4j.version>1.7.32</slf4j.version>
-        <logback.version>1.2.6</logback.version>
+        <vertx.version>4.4.5</vertx.version>
+        <hazelcast.version>5.0.5</hazelcast.version>
+        <slf4j.version>2.0.4</slf4j.version>
+        <logback.version>1.4.11</logback.version>
         <junit.version>4.13.2</junit.version>
     </properties>
 


### PR DESCRIPTION
downgrade hazelcast to match major and minor version.
the micro was updated in june 2023